### PR TITLE
Generalize bandpass

### DIFF
--- a/code/commands/de_SimulatorUber.m
+++ b/code/commands/de_SimulatorUber.m
@@ -44,14 +44,16 @@ function [trn, tst, dirs] = de_SimulatorUber(training_info, testing_info, opts, 
   %%%%%%%%%%%%%%%%
   % Train classifiers on images run through the pre-trained autoencoders
   %%%%%%%%%%%%%%%%%
-  testing_info_split  = mfe_split('/', testing_info);
-  guru_assert(length(testing_info_split) >= 2, 'testing info must have correct format: expt/stimset[/tasktype]');
-  testing_expt      = testing_info_split{1};
-  testing_imageset  = testing_info_split{2};
-  if length(testing_info_split)==2
-      testing_task = '';
-  else
-      testing_task      = testing_info_split{3};
+  if ~isempty(testing_info)
+    testing_info_split  = mfe_split('/', testing_info);
+    guru_assert(length(testing_info_split) >= 2, 'testing info must have correct format: expt/stimset[/tasktype]');
+    testing_expt      = testing_info_split{1};
+    testing_imageset  = testing_info_split{2};
+    if length(testing_info_split)==2
+        testing_task = '';
+    else
+        testing_task      = testing_info_split{3};
+    end;
 
     p_args = { args{:}, 'uberpath', dirs };
 

--- a/code/commands/de_SimulatorUber.m
+++ b/code/commands/de_SimulatorUber.m
@@ -2,6 +2,15 @@ function [trn, tst, dirs] = de_SimulatorUber(training_info, testing_info, opts, 
 %
 % Run sergent task by training on all images
 
+  % parse opts
+  if isstruct(opts)
+    uber_opts = opts.uber;
+    task_opts = opts.task;
+  else
+    uber_opts = opts;
+    task_opts = opts;
+  end;
+
   %%%%%%%%%%%%%%%%
   % Train autoencoders on some set of images
   %%%%%%%%%%%%%%%%%
@@ -22,7 +31,7 @@ function [trn, tst, dirs] = de_SimulatorUber(training_info, testing_info, opts, 
   tough_ac_arg_idx = sort([ 2 * tough_ac_argname_idx - 1, 2 * tough_ac_argname_idx]);
   uber_args = uber_args(tough_ac_arg_idx);
 
-  [trn.mSets, trn.models, trn.stats] = de_Simulator(training_expt, training_imageset, '', opts, uber_args{:});
+  [trn.mSets, trn.models, trn.stats] = de_Simulator(training_expt, training_imageset, '', uber_opts, uber_args{:});
 
   % Get the autoencoder directories
   ac = [trn.models(1,:).ac];
@@ -43,8 +52,8 @@ function [trn, tst, dirs] = de_SimulatorUber(training_info, testing_info, opts, 
       testing_task = '';
   else
       testing_task      = testing_info_split{3};
+
+    p_args = { args{:}, 'uberpath', dirs };
+
+    [tst.mSets, tst.models, tst.stats] = de_Simulator(testing_expt, testing_imageset, testing_task, task_opts, p_args{:});
   end;
-
-  p_args = { args{:}, 'uberpath', dirs };
-
-  [tst.mSets, tst.models, tst.stats] = de_Simulator(testing_expt, testing_imageset, testing_task, opts, p_args{:});

--- a/code/train/de_connector2D.m
+++ b/code/train/de_connector2D.m
@@ -60,7 +60,7 @@ function [Con,mu] = de_connector2D(sI,sH,hpl,numCon,distn,rds,sig,dbg,tol,weight
         case {'gam','gamma','game','gammae'}
           k = rds^2/sig;
           theta = sig/rds;
-        case {'norm','norme','norme2','normem2','normn', 'normeh', 'normepK', 'normemK'}
+        case {'norm','norme','norme2','normem2','normem3', 'normn', 'normeh', 'normepK', 'normemK'}
           if (rds ~= 0.0) && ~isnan(rds), warning('Ignoring non-zero rds=%4.1f', rds); end;
         case {'normr', 'normre'}
         case {'full','fulle'}, opts={'nofill'};

--- a/experiments/bandpass/bandpass_by_task.m
+++ b/experiments/bandpass/bandpass_by_task.m
@@ -31,13 +31,12 @@ while high <= max(imgsiz)/2
     low = low + bandpass_step;
     high = high + bandpass_step;
     close all;
-        
+
 end
 
 figure;
 errorbar(center_freq, results, errors);
 xlabel('Center Frequency (cycles/ img)');
 ylabel('Sum Squared Error');
-title(sprintf('SSE vs Frequency: Bandpass Step %d, Bandpass Width %d', ... 
+title(sprintf('SSE vs Frequency: Bandpass Step %d, Bandpass Width %d', ...
     bandpass_step, bandpass_width));
-        

--- a/experiments/bandpass/bandpass_by_task.m
+++ b/experiments/bandpass/bandpass_by_task.m
@@ -1,42 +1,48 @@
-scale=2; % if blob-dot, scale=2. else scale=1
+function bandpass_by_task(n_steps, window_steps, args_path, task_info, extra_opts, extra_args)
+  if ~exist('extra_opts', 'var'), extra_opts = {}; end;
+  if ~exist('extra_args', 'var'), extra_args = {}; end;
 
-imgsiz = [34, 25] * scale;
-bandpass_width = 4;
-bandpass_step = 1 * scale;
+  % Get args & opts from function
+  [dir_name, file_name] = fileparts(args_path);
+  addpath(dir_name);
+  args_fn = str2func(file_name);
+  [args, opts] = args_fn();
+  args = [args, extra_args];
+  opts = [opts, extra_opts];
 
-scriptname = 'slotnick_etal_2001/blob-dot/categorical';
+  % Pre-train the autoencoder on full-fidelity. This will get us the image size.
+  [trn] = de_SimulatorUber('vanhateren/250', '', opts, args);
+  max_freq = max(trn.mSets.nInput / 2);
+  bandpass_step =  max_freq / n_steps;
+  window_size = bandpass_step * window_steps;
 
-low = 0;
-high = low + bandpass_width;
+  % Train the classifier on the bandpass-filtered stimuli.
+  tmp = linspace(0, max_freq, n_steps + 2);
+  center_freqs = tmp(2:end-1);
+  low_freqs = max(0, center_freqs - window_size/2);
+  high_freqs = min(max_freq, center_freqs + window_size/2);
 
-ds = 'test';
-center_freq = [];
-results = [];
-errors = [];
-[args, opts]  = uber_slotnick_args('p.dropout', 0.7, 'sigma', [10, 10]);
-orig_opts = opts;
+  means = zeros(length(trn.mSets.sigma), length(center_freqs));
+  stderrs = zeros(size(means));
 
-while high <= max(imgsiz)/2
-    opts = [orig_opts, 'bandpass', [low, high]];
-    [trn, tst] = de_SimulatorUber('vanhateren/250', scriptname, opts, args);
-    stats = tst.stats;
-    left = stats.rej.cc.perf.(ds){end};
-    runs = size(left{1});
-    runs = runs(1);
-    avg = mean(cellfun(@(d) mean(d(:)), left)); %For this script, assume sigmas are same
-    results = [results, avg];
-    center_freq = [center_freq, (low + high)/2];
-    stddev = std2([left{1}, left{2}]);
-    errors = [errors, stddev/sqrt(runs)];
-    low = low + bandpass_step;
-    high = high + bandpass_step;
+  for si=1:n_steps
+    % Train the model
+    cur_opts = struct( ...
+        'uber', {opts}, ...
+        'task', {[opts, 'bandpass', [low_freqs(si), high_freqs(si)]]} ...
+    );
+    [~, tst] = de_SimulatorUber('vanhateren/250', task_info, cur_opts, args);
     close all;
 
+    % Store mean performance
+    means(:, si) = cellfun(@(x) mean(x), tst.stats.rej.p.err.vals);
+    stderrs(:, si) = cellfun(@(x) std(x), tst.stats.rej.p.err.vals) / sqrt(tst.mSets.runs);
 end
 
 figure;
-errorbar(center_freq, results, errors);
-xlabel('Center Frequency (cycles/ img)');
-ylabel('Sum Squared Error');
-title(sprintf('SSE vs Frequency: Bandpass Step %d, Bandpass Width %d', ...
-    bandpass_step, bandpass_width));
+errorbar(repmat(center_freqs, [2, 1])', (means'), (stderrs'), 'LineWidth', 2.0);
+set(gca, 'FontSize', 14);
+legend(guru_csprintf('%.2f', num2cell(trn.mSets.sigma)), 'FontSize', 12);
+xlabel('Center Frequency (cycles/ img)', 'FontSize', 14);
+ylabel('Sum Squared Error', 'FontSize', 14);
+title(sprintf('SSE vs Frequency; Bandpass Step=%.2f, Width=%.2f', bandpass_step, window_size), 'FontSize', 16);


### PR DESCRIPTION
This takes the `tests/test_bandpass.m` script, and generalizes it into a callable function.

```
EDU>> bandpass_by_task(10, 2, '../34x25/sergent_1982/uber_sergent_args', 'sergent_1982/de/sergent', {}, {'runs', 5})
```

* Arg 1: # of frequency steps to take. This will take steps of 1.7 cycles/image (34/2 /10)
* Arg 2: width of window (in terms of frequency steps). 3.4 cycles/image here.
* Arg 3: path to the argument file that you want to load.
* Arg 4: string for the experiment you want to run.
* Arg 5: any 'override' options
* Arg 6: any 'override' args.

![image](https://cloud.githubusercontent.com/assets/4072455/20444414/d99bf308-ad85-11e6-8e05-6057654cd17a.png)
