### PR TITLE
Allow for task breakdown by TLBL

### DIFF
--- a/code/lib/guru/opts/guru_stampProps.m
+++ b/code/lib/guru/opts/guru_stampProps.m
@@ -6,6 +6,12 @@ function mSets = guru_stampProps(varargin)
     mSets = struct();
     error('No input arguments')
 
+  % Passed in a cell array
+  elseif length(varargin) == 1 && iscell(varargin)
+      varargin = varargin{1};
+      mSets = guru_stampProps(varargin{:});
+      return;
+      
   % Odd # of inputs; grab original object, and expect strings at every second input
   elseif isstruct(varargin{1})
     if 0==mod(length(varargin),2), error('You have an odd number of args [first arg is the object]'); end;

--- a/experiments/bandpass/bandpass_by_task.m
+++ b/experiments/bandpass/bandpass_by_task.m
@@ -24,6 +24,11 @@ function bandpass_by_task(n_steps, window_steps, args_path, task_info, extra_opt
 
   means = zeros(length(trn.mSets.sigma), length(center_freqs));
   stderrs = zeros(size(means));
+  task1_means = zeros(size(means));
+  task2_means = zeros(size(means));
+  task1_ste = zeros(size(means));
+  task2_ste = zeros(size(means));
+
 
   for si=1:n_steps
     % Train the model
@@ -37,8 +42,44 @@ function bandpass_by_task(n_steps, window_steps, args_path, task_info, extra_opt
     % Store mean performance
     means(:, si) = cellfun(@(x) mean(x), tst.stats.rej.p.err.vals);
     stderrs(:, si) = cellfun(@(x) std(x), tst.stats.rej.p.err.vals) / sqrt(tst.mSets.runs);
-end
+    
+    % Do breakdown for task type
+    mSets = tst.mSets;
+    TLAB = mSets.data.test.TLAB;
+    nSig = size(tst.models, 2);
+    ps = [tst.models.p];
+    o = [ps.output]; %this combines all sigmas together... need a smarter fix for multiple sigmas
+    temp   = de_calcPErr( vertcat(o.test), mSets.data.test.T, 2);
+    
+    if (strcmp(tst.mSets.expt, 'slotnick_etal_2001'))
+    	trial_types = {'easy', 'hard'};
+    elseif (strcmp(tst.mSets.expt, 'sergent_1982'))
+        trial_types = {'L-S+', 'L+S-'};
+    end
+    type1_perf = temp(:, guru_instr(TLAB, trial_types{1})); %2 freqs
+    type2_perf = temp(:, guru_instr(TLAB, trial_types{2}));
+    
+    %Reshape array to separate out sigmas
+    type1_perf = reshape(type1_perf', size(type1_perf, 2), [], nSig);
+    type2_perf = reshape(type2_perf', size(type2_perf, 2), [], nSig);
 
+    task1_means(:, si) = reshape(mean(mean(type1_perf)), [nSig, 1]);
+    task2_means(:, si) = reshape(mean(mean(type2_perf)), [nSig, 1]);
+    
+    task1_ste(:, si) = std(reshape(type1_perf, [], nSig)) ./ ...
+        (numel(type1_perf) / nSig); %Total number of values per sigma
+    task2_ste(:, si) = std(reshape(type2_perf, [], nSig)) ./ ...
+        (numel(type2_perf) / nSig);
+
+  end
+
+global_min = min(min(task1_means(:)), min(task2_means(:)));
+global_min = min(global_min, min(means(:)));
+
+global_max = max(max(task1_means(:)), max(task2_means(:)));
+global_max = max(global_max, max(means(:)));
+
+  
 figure;
 errorbar(repmat(center_freqs, [2, 1])', (means'), (stderrs'), 'LineWidth', 2.0);
 set(gca, 'FontSize', 14);
@@ -46,3 +87,24 @@ legend(guru_csprintf('%.2f', num2cell(trn.mSets.sigma)), 'FontSize', 12);
 xlabel('Center Frequency (cycles/ img)', 'FontSize', 14);
 ylabel('Sum Squared Error', 'FontSize', 14);
 title(sprintf('SSE vs Frequency; Bandpass Step=%.2f, Width=%.2f', bandpass_step, window_size), 'FontSize', 16);
+%ylim([global_min, global_max]); %Used if all axes should be relative.
+
+figure;
+errorbar(repmat(center_freqs, [2, 1])', (task1_means'), (task1_ste'), 'LineWidth', 2.0);
+set(gca, 'FontSize', 14);
+legend(guru_csprintf('%.2f', num2cell(trn.mSets.sigma)), 'FontSize', 12);
+xlabel('Center Frequency (cycles/ img)', 'FontSize', 14);
+ylabel('Sum Squared Error', 'FontSize', 14);
+title(sprintf('Task=%s; SSE vs Frequency; Bandpass Step=%.2f, Width=%.2f', trial_types{1}, bandpass_step, window_size), 'FontSize', 16);
+%ylim([global_min, global_max]);
+
+figure;
+errorbar(repmat(center_freqs, [2, 1])', (task2_means'), (task2_ste'), 'LineWidth', 2.0);
+set(gca, 'FontSize', 14);
+legend(guru_csprintf('%.2f', num2cell(trn.mSets.sigma)), 'FontSize', 12);
+xlabel('Center Frequency (cycles/ img)', 'FontSize', 14);
+ylabel('Sum Squared Error', 'FontSize', 14);
+title(sprintf('Task=%s; SSE vs Frequency; Bandpass Step=%.2f, Width=%.2f', trial_types{2}, bandpass_step, window_size), 'FontSize', 16);
+%ylim([global_min, global_max]);
+
+

--- a/experiments/bandpass/bandpass_by_task.m
+++ b/experiments/bandpass/bandpass_by_task.m
@@ -1,14 +1,30 @@
-function bandpass_by_task(n_steps, window_steps, args_path, task_info, extra_opts, extra_args)
-  if ~exist('extra_opts', 'var'), extra_opts = {}; end;
-  if ~exist('extra_args', 'var'), extra_args = {}; end;
+function bandpass_by_task(args_path, task_info, varargin)
+%
+%
+%    if (strcmp(tst.mSets.expt, 'slotnick_etal_2001'))
+%      trial_types = {'easy', 'hard'};
+%    elseif (strcmp(tst.mSets.expt, 'sergent_1982'))
+%        trial_types = {'L-S+', 'L+S-'};
+%    end
+%
+
+  fn_args = guru_stampProps([{ ...
+    'n_steps', 10, 'window_steps', 2, ...
+    'trial_types', {}, ...
+    'opts', {}, 'args', {}, ...
+    }, varargin ...
+  ]);
+  n_steps = fn_args.n_steps;
+  window_steps = fn_args.window_steps;
+  trial_types = fn_args.trial_types;
 
   % Get args & opts from function
   [dir_name, file_name] = fileparts(args_path);
   addpath(dir_name);
   args_fn = str2func(file_name);
   [args, opts] = args_fn();
-  args = [args, extra_args];
-  opts = [opts, extra_opts];
+  args = [args, fn_args.args];
+  opts = [opts, fn_args.opts];
 
   % Pre-train the autoencoder on full-fidelity. This will get us the image size.
   [trn] = de_SimulatorUber('vanhateren/250', '', opts, args);
@@ -22,7 +38,10 @@ function bandpass_by_task(n_steps, window_steps, args_path, task_info, extra_opt
   low_freqs = max(0, center_freqs - window_size/2);
   high_freqs = min(max_freq, center_freqs + window_size/2);
 
-  means = zeros(length(trn.mSets.sigma), length(center_freqs));
+  n_runs = trn.mSets.runs;
+  n_sigmas = length(trn.mSets.sigma);
+  n_plots = 1 + length(trial_types);
+  means = zeros(n_sigmas, length(center_freqs), n_plots);
   stderrs = zeros(size(means));
   task1_means = zeros(size(means));
   task2_means = zeros(size(means));
@@ -32,79 +51,65 @@ function bandpass_by_task(n_steps, window_steps, args_path, task_info, extra_opt
 
   for si=1:n_steps
     % Train the model
-    cur_opts = struct( ...
-        'uber', {opts}, ...
-        'task', {[opts, 'bandpass', [low_freqs(si), high_freqs(si)]]} ...
+    cur_opts = guru_stampProps( ...
+        'uber', opts, ...
+        'task', [opts, 'bandpass', [low_freqs(si), high_freqs(si)]] ...
     );
     [~, tst] = de_SimulatorUber('vanhateren/250', task_info, cur_opts, args);
     close all;
 
+
+    % Grab the raw output
+    n_trials = numel(tst.mSets.data.test.TLAB);
+    p = [tst.models.p];
+    o = [p.output];
+    err = de_calcPErr( vertcat(o.test), tst.mSets.data.test.T, tst.mSets.p.errorType);
+    err = reshape(err, [n_runs, n_sigmas, n_trials]);
+    err = permute(err, [1, 3, 2]);  % n_sigmas at the end
+
     % Store mean performance
-    means(:, si) = cellfun(@(x) mean(x), tst.stats.rej.p.err.vals);
-    stderrs(:, si) = cellfun(@(x) std(x), tst.stats.rej.p.err.vals) / sqrt(tst.mSets.runs);
-    
-    % Do breakdown for task type
-    mSets = tst.mSets;
-    TLAB = mSets.data.test.TLAB;
-    nSig = size(tst.models, 2);
-    ps = [tst.models.p];
-    o = [ps.output]; %this combines all sigmas together... need a smarter fix for multiple sigmas
-    temp   = de_calcPErr( vertcat(o.test), mSets.data.test.T, 2);
-    
-    if (strcmp(tst.mSets.expt, 'slotnick_etal_2001'))
-    	trial_types = {'easy', 'hard'};
-    elseif (strcmp(tst.mSets.expt, 'sergent_1982'))
-        trial_types = {'L-S+', 'L+S-'};
-    end
-    type1_perf = temp(:, guru_instr(TLAB, trial_types{1})); %2 freqs
-    type2_perf = temp(:, guru_instr(TLAB, trial_types{2}));
-    
-    %Reshape array to separate out sigmas
-    type1_perf = reshape(type1_perf', size(type1_perf, 2), [], nSig);
-    type2_perf = reshape(type2_perf', size(type2_perf, 2), [], nSig);
-
-    task1_means(:, si) = reshape(mean(mean(type1_perf)), [nSig, 1]);
-    task2_means(:, si) = reshape(mean(mean(type2_perf)), [nSig, 1]);
-    
-    task1_ste(:, si) = std(reshape(type1_perf, [], nSig)) ./ ...
-        (numel(type1_perf) / nSig); %Total number of values per sigma
-    task2_ste(:, si) = std(reshape(type2_perf, [], nSig)) ./ ...
-        (numel(type2_perf) / nSig);
-
+    for ti = 0:length(trial_types)  % 0 = all trials.
+      cur_err = err;
+      if ti > 0
+        good_trial_idx = strcmp(trial_types{ti}, tst.mSets.data.test.TLAB);
+        cur_err = cur_err(:, good_trial_idx, :);
+      end;
+      cur_err = reshape(cur_err, [n_runs * size(cur_err, 2), n_sigmas]);
+      means(:, si, ti + 1) = mean(cur_err, 1);
+      stderrs(:, si, ti + 1) = std(cur_err, [], 1) / sqrt(n_runs);
+    end;
   end
 
-global_min = min(min(task1_means(:)), min(task2_means(:)));
-global_min = min(global_min, min(means(:)));
+  titles = guru_csprintf( ...
+      sprintf( ...
+        'SSE vs Frequency (%%s)\nBandpass Step=%.2f, Width=%.2f', ...
+        bandpass_step, window_size ...
+      ), ...
+      [{'All', trial_types}] ...
+  );
 
-global_max = max(max(task1_means(:)), max(task2_means(:)));
-global_max = max(global_max, max(means(:)));
-
-  
-figure;
-errorbar(repmat(center_freqs, [2, 1])', (means'), (stderrs'), 'LineWidth', 2.0);
-set(gca, 'FontSize', 14);
-legend(guru_csprintf('%.2f', num2cell(trn.mSets.sigma)), 'FontSize', 12);
-xlabel('Center Frequency (cycles/ img)', 'FontSize', 14);
-ylabel('Sum Squared Error', 'FontSize', 14);
-title(sprintf('SSE vs Frequency; Bandpass Step=%.2f, Width=%.2f', bandpass_step, window_size), 'FontSize', 16);
-%ylim([global_min, global_max]); %Used if all axes should be relative.
-
-figure;
-errorbar(repmat(center_freqs, [2, 1])', (task1_means'), (task1_ste'), 'LineWidth', 2.0);
-set(gca, 'FontSize', 14);
-legend(guru_csprintf('%.2f', num2cell(trn.mSets.sigma)), 'FontSize', 12);
-xlabel('Center Frequency (cycles/ img)', 'FontSize', 14);
-ylabel('Sum Squared Error', 'FontSize', 14);
-title(sprintf('Task=%s; SSE vs Frequency; Bandpass Step=%.2f, Width=%.2f', trial_types{1}, bandpass_step, window_size), 'FontSize', 16);
-%ylim([global_min, global_max]);
-
-figure;
-errorbar(repmat(center_freqs, [2, 1])', (task2_means'), (task2_ste'), 'LineWidth', 2.0);
-set(gca, 'FontSize', 14);
-legend(guru_csprintf('%.2f', num2cell(trn.mSets.sigma)), 'FontSize', 12);
-xlabel('Center Frequency (cycles/ img)', 'FontSize', 14);
-ylabel('Sum Squared Error', 'FontSize', 14);
-title(sprintf('Task=%s; SSE vs Frequency; Bandpass Step=%.2f, Width=%.2f', trial_types{2}, bandpass_step, window_size), 'FontSize', 16);
-%ylim([global_min, global_max]);
+  % Draw figure; once for log(mean) in case error is wacky
+  draw_figure(means, stderrs, titles, trn.mSets.sigma);
+  draw_figure(log(means), log(stderrs), titles, trn.mSets.sigma);
 
 
+function draw_figure(means, stderrs, titles, sigmas)
+
+  % Output the figures
+  figure('Position', [0, 0, 1200 600]);
+  for ti=1:length(titles)  % will output each type, plus all.
+
+    subplot(1, 1 + length(trial_types), ti);
+    errorbar( ...
+      repmat(center_freqs, [2, 1])', ...
+      means(:, :, ti)', stderrs(:, :, ti)', ...
+      'LineWidth', 2.0 ...
+    );
+    set(gca, 'FontSize', 14);
+    legend(guru_csprintf('%.2f', num2cell(sigmas)), 'FontSize', 12);
+    title(titles{ti}, 'FontSize', 12);
+    xlabel('Center Frequency (cycles/ img)', 'FontSize', 14);
+    if ti == 0
+      ylabel('Sum Squared Error', 'FontSize', 14);
+    end;
+  end;


### PR DESCRIPTION
This is hard-coded so that `trial_types` can't be more than two strings, and you have to specify which TLBLs for an experiment type explicitly.

The rest isn't hard-coded, though, so this works for a single or multiple sigmas, and for any two `trial_types`, regardless of if they comprise the entire dataset or just a portion of it.

<img width="1430" alt="screen shot 2016-11-21 at 3 56 04 pm" src="https://cloud.githubusercontent.com/assets/7337790/20519565/43bcdd90-b058-11e6-954f-fe8572f7768d.png">

<img width="1440" alt="screen shot 2016-11-21 at 3 17 50 pm" src="https://cloud.githubusercontent.com/assets/7337790/20519577/5248d170-b058-11e6-9e8f-0c05e8a92af0.png">
