### PR TITLE
Fix sergent

### DIFF
--- a/code/_expts/sergent_1982/analyze/stats/de_models2LS.m
+++ b/code/_expts/sergent_1982/analyze/stats/de_models2LS.m
@@ -41,27 +41,8 @@ function [LS_permodel, LS_mean, LS_stde, LS_raw_permodel] = de_models2LS(models,
     o_p       = reshape(horzcat(o.test),[numel(o(1).test),length(o)])';  % # models x # trials
     raw_error = de_calcPErr( o_p, mSets.data.test.T, errorType );        % # models x # trials
 
-    calc_raw_error = zeros(runs, length(mSets.data.test.T));
-    for mi=1:runs
-      if strcmp(mSets.deType, 'de-stacked')
-          m = de_LoadProps(m, 'p', 'Weights');
-          [oact] = guru_nnExec(m.p, huact, mSets.data.test.T);
-      else
-          m = de_LoadProps(models(mi), 'ac', 'Weights');
-          m = de_LoadProps(m, 'p', 'Weights');
-          [~, ~, huact] = guru_nnExec(m.ac, mSets.data.test.X, mSets.data.test.X(1:end-1,:));
-          [oact] = guru_nnExec(m.p, huact, mSets.data.test.T);
-      end;
-      calc_raw_error(mi, :) = de_calcPErr( oact, mSets.data.test.T, errorType );        % # models x # trials
-    end;
-
-    if any(raw_error(:) - calc_raw_error(:))
-        raw_error - calc_raw_error
-        raw_error = calc_raw_error;
-    end;
-
     % Calc ls for each model
-    ndupes           = size(oact, 2) / length(mSets.data.test.ST);  % sometimes we duplicate outputs for training, for fun.
+    ndupes           = size(raw_error, 2) / length(mSets.data.test.ST);  % sometimes we duplicate outputs for training, for fun.
     allidx           = cell(num_trial_types, 1);
     LS_permodel      = zeros(runs, num_trial_types);
     LS_raw_permodel  = cell(runs, num_trial_types);

--- a/code/train/de_DE.m
+++ b/code/train/de_DE.m
@@ -52,23 +52,21 @@ function [model] = de_DE(model)
     fprintf('\nwts {in=>hid: [%5.2f %5.2f]}; {hid=>out: [%5.2f %5.2f]}', ih_mn,ih_mx,ho_mn,ho_mx);
   end;
 
-  % Even if it's cached, we need the output characteristics
-  %   of the model.
-  if (~isfield(model.ac,'hu'))
-      % Make sure the autoencoder's connectivity is set.
-      model = de_LoadProps(model, 'ac', 'Weights');
-      model.ac.Conn = (model.ac.Weights~=0);
-
-      [model.ac.output.train,~,model.ac.hu.train] = guru_nnExec(model.ac, model.data.train.X, model.data.train.X(1:end-1,:));
-      [model.ac.output.test, ~,model.ac.hu.test]  = guru_nnExec(model.ac, model.data.test.X,  model.data.test.X(1:end-1,:));
-  end;
-
-
   %--------------------------------%
   % Create and train the perceptron
   %--------------------------------%
   if (isfield(model, 'p'))
       if (~model.p.cached)
+
+      % We need the output characteristics of the model.
+      if (~isfield(model.ac,'hu'))
+          % Make sure the autoencoder's connectivity is set.
+          model = de_LoadProps(model, 'ac', 'Weights');
+          model.ac.Conn = (model.ac.Weights~=0);
+          [model.ac.output.train,~,model.ac.hu.train] = guru_nnExec(model.ac, model.data.train.X, model.data.train.X(1:end-1,:));
+          [model.ac.output.test, ~,model.ac.hu.test]  = guru_nnExec(model.ac, model.data.test.X,  model.data.test.X(1:end-1,:));
+      end;
+
         good_train = ~isnan(sum(model.data.train.T,1));
         nTrials    = sum(good_train); % count the # of trials with no NaN anywhere in them
 


### PR DESCRIPTION
Things were so darn slow running locally, I investigated two places where we were computing network outputs from scratch.

* Updated main `de_DE` script, to only compute hidden unit outputs if needed (for perceptron training).
* Removed computation of outputs from Sergent analysis code. They weren't doing proper z-scoring of the data anyway.

This does change the sergent results, so those need to be re-run.